### PR TITLE
Fix bound handling in ND interpolator

### DIFF
--- a/src/math/Interpolation.h
+++ b/src/math/Interpolation.h
@@ -1,15 +1,16 @@
 #ifndef INTERPOLATION_H
 #define INTERPOLATION_H
 
-#include <vector>
 #include "FGMatrix.h"
 #include "VectorHash.h"
+#include <vector>
 
-double interpolate(const std::vector<double>& queryPoint, const PointCloud& points);
+double interpolate(const std::vector<double> &queryPoint,
+                   const PointCloud &points);
 
 // Function prototypes
-double findLowerBound(const std::vector<double>& vec, double value);
-double getValueAtPoint(const PointCloud& points, const std::vector<double>& queryCoords);
+double getValueAtPoint(const PointCloud &points,
+                       const std::vector<double> &queryCoords);
 double clamp(double value, double min, double max);
 
 // Constants

--- a/src/math/Interpolation.h
+++ b/src/math/Interpolation.h
@@ -10,7 +10,6 @@ double interpolate(const std::vector<double>& queryPoint, const PointCloud& poin
 // Function prototypes
 double findLowerBound(const std::vector<double>& vec, double value);
 double getValueAtPoint(const PointCloud& points, const std::vector<double>& queryCoords);
-double interpolateRecursive(const std::vector<double>& queryPoint, const PointCloud& points, size_t dim);
 double clamp(double value, double min, double max);
 
 // Constants

--- a/tests/unit_tests/InterpolationTest.h
+++ b/tests/unit_tests/InterpolationTest.h
@@ -1,426 +1,312 @@
-#include <cxxtest/TestSuite.h>
 #include "math/Interpolation.h"
-#include <random>
 #include <chrono>
-#include <iostream>
-#include <iomanip>
-#include <unordered_set>
 #include <cmath>
+#include <cxxtest/TestSuite.h>
+#include <iomanip>
+#include <iostream>
 #include <limits>
+#include <random>
+#include <unordered_set>
 
-class InterpolationTest : public CxxTest::TestSuite
-{
+class InterpolationTest : public CxxTest::TestSuite {
 public:
-    // Non-linear continuous function for 4D
-    static double nonLinearFunction(const std::vector<double>& x) {
-        return std::sqrt(std::pow(2 * std::cos(x[0]) + std::sin(x[1]), 2) + 
-                         std::pow(2 * std::sin(x[2]) + std::cos(x[3]), 2) + 1);
+  // Non-linear continuous function for multi-dimensional testing
+  static double nonLinearFunction(const std::vector<double> &x) {
+    double sum = 0;
+    for (size_t i = 0; i < x.size(); ++i) {
+      sum += std::sin(x[i]) * std::cos(x[(i + 1) % x.size()]);
+    }
+    return sum / x.size();
+  }
+
+  // Tolerance function
+  static double calculateTolerance(const std::vector<double> &point,
+                                   const PointCloud &points) {
+    const double h = 1e-4; // Small step size for numerical differentiation
+    std::vector<double> gradient(point.size());
+
+    // Calculate numerical gradient
+    for (size_t i = 0; i < point.size(); ++i) {
+      std::vector<double> point_plus = point;
+      std::vector<double> point_minus = point;
+      point_plus[i] += h;
+      point_minus[i] -= h;
+      gradient[i] =
+          (nonLinearFunction(point_plus) - nonLinearFunction(point_minus)) /
+          (2 * h);
     }
 
-    // New tolerance function
-    static double calculateTolerance(const std::vector<double>& point, const PointCloud& points) {
-        const double h = 1e-4; // Small step size for numerical differentiation
-        std::vector<double> gradient(point.size());
-
-        // Calculate numerical gradient
-        for (size_t i = 0; i < point.size(); ++i) {
-            std::vector<double> point_plus = point;
-            std::vector<double> point_minus = point;
-            point_plus[i] += h;
-            point_minus[i] -= h;
-            gradient[i] = (nonLinearFunction(point_plus) - nonLinearFunction(point_minus)) / (2 * h);
-        }
-
-        // Calculate maximum gradient magnitude
-        double max_gradient = 0.0;
-        for (double g : gradient) {
-            max_gradient = std::max(max_gradient, std::abs(g));
-        }
-
-        // Calculate average grid spacing
-        double avg_spacing = 0.0;
-        for (const auto& dim_values : points.uniqueValues) {
-            avg_spacing += (dim_values.back() - dim_values.front()) / (dim_values.size() - 1);
-        }
-        avg_spacing /= point.size();
-
-        // Tolerance based on local linearity and grid spacing
-        double base_tolerance = max_gradient * avg_spacing * avg_spacing;
-
-        // Add a small absolute tolerance to handle near-zero values
-        double abs_tolerance = 1e-6;
-
-        return std::max(base_tolerance, abs_tolerance);
+    // Calculate maximum gradient magnitude
+    double max_gradient = 0.0;
+    for (double g : gradient) {
+      max_gradient = std::max(max_gradient, std::abs(g));
     }
 
-    PointCloud createRandomPointCloud(int numDimensions, int pointsPerDimension, double minValue = 0.0, double maxValue = 2 * M_PI)
-    {
-        PointCloud points;
-        points.numDimensions = numDimensions;
-        points.uniqueValues.resize(numDimensions);
+    // Calculate average grid spacing
+    double avg_spacing = 0.0;
+    for (const auto &dim_values : points.uniqueValues) {
+      avg_spacing +=
+          (dim_values.back() - dim_values.front()) / (dim_values.size() - 1);
+    }
+    avg_spacing /= point.size();
 
-        std::random_device rd;
-        std::mt19937 gen(rd());
-        std::uniform_real_distribution<> spacingDis(0.1, 1.0); // Random spacing between 0.1 and 1.0
+    // Tolerance based on local linearity and grid spacing
+    double base_tolerance = max_gradient * avg_spacing * avg_spacing;
 
-        // Generate random spacing for each dimension
-        std::vector<double> spacings(numDimensions);
-        for (int dim = 0; dim < numDimensions; ++dim) {
-            spacings[dim] = spacingDis(gen);
-        }
+    // Add a small absolute tolerance to handle near-zero values
+    double abs_tolerance = 1e-6;
 
-        // Create evenly distributed grid with random spacing
-        for (int dim = 0; dim < numDimensions; ++dim) {
-            double range = maxValue - minValue;
-            double spacing = spacings[dim] * range / (pointsPerDimension - 1);
-            for (int j = 0; j < pointsPerDimension; ++j) {
-                double value = minValue + j * spacing;
-                points.uniqueValues[dim].push_back(value);
-            }
-        }
+    return std::max(base_tolerance, abs_tolerance);
+  }
 
-        // Generate all permutations of points
-        std::vector<int> indices(numDimensions, 0);
-        while (true) {
-            std::vector<double> point(numDimensions);
-            for (int i = 0; i < numDimensions; ++i) {
-                point[i] = points.uniqueValues[i][indices[i]];
-            }
-            points.pointMap[point] = nonLinearFunction(point);
+  PointCloud createRandomPointCloud(int numDimensions, int pointsPerDimension,
+                                    double minValue = 0.0,
+                                    double maxValue = 2 * M_PI) {
+    PointCloud points;
+    points.numDimensions = numDimensions;
+    points.uniqueValues.resize(numDimensions);
 
-            // Increment indices
-            int dim = 0;
-            while (dim < numDimensions && ++indices[dim] == pointsPerDimension) {
-                indices[dim] = 0;
-                ++dim;
-            }
-            if (dim == numDimensions) break;
-        }
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_real_distribution<> spacingDis(0.1, 1.0);
 
-        return points;
+    // Generate random spacing for each dimension
+    std::vector<double> spacings(numDimensions);
+    for (int dim = 0; dim < numDimensions; ++dim) {
+      spacings[dim] = spacingDis(gen);
     }
 
-    void testBasicInterpolation4D()
-    {
-
-        std::cout << "\n#########################################" << std::endl;
-        std::cout << "Starting testBasicInterpolation4D\n" << std::endl;
-        
-        PointCloud points;
-        points.numDimensions = 4;
-        points.uniqueValues = {{0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}};
-
-        // Set up a 4D hypercube
-        for (int i = 0; i <= 1; ++i) {
-            for (int j = 0; j <= 1; ++j) {
-                for (int k = 0; k <= 1; ++k) {
-                    for (int l = 0; l <= 1; ++l) {
-                        std::vector<double> point = {static_cast<double>(i), static_cast<double>(j), 
-                                                     static_cast<double>(k), static_cast<double>(l)};
-                        points.pointMap[point] = nonLinearFunction(point);
-                    }
-                }
-            }
-        }
-
-        // Test interpolation at the center of the hypercube
-        std::vector<double> queryPoint = {0.5, 0.5, 0.5, 0.5};
-        double result = interpolate(queryPoint, points);
-        double expected = nonLinearFunction(queryPoint);
-        double tolerance = calculateTolerance(queryPoint, points);
-        TS_ASSERT_DELTA(result, expected, tolerance);
-        
-        std::cout << "\nFinished testBasicInterpolation4D" << std::endl;
-        std::cout << "#########################################\n" << std::endl;
+    // Create evenly distributed grid with random spacing
+    for (int dim = 0; dim < numDimensions; ++dim) {
+      double range = maxValue - minValue;
+      double spacing = spacings[dim] * range / (pointsPerDimension - 1);
+      for (int j = 0; j < pointsPerDimension; ++j) {
+        double value = minValue + j * spacing;
+        points.uniqueValues[dim].push_back(value);
+      }
     }
 
-    void testEdgeCases4D()
-    {
-        std::cout << "\n#########################################" << std::endl;
-        std::cout << "Starting testEdgeCases4D\n" << std::endl;
+    // Generate all permutations of points
+    std::vector<int> indices(numDimensions, 0);
+    while (true) {
+      std::vector<double> point(numDimensions);
+      for (int i = 0; i < numDimensions; ++i) {
+        point[i] = points.uniqueValues[i][indices[i]];
+      }
+      points.pointMap[point] = nonLinearFunction(point);
 
-        PointCloud points;
-        points.numDimensions = 4;
-        points.uniqueValues = {{0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}};
-
-        // Set up a 4D hypercube with function values
-        for (int i = 0; i <= 1; ++i) {
-            for (int j = 0; j <= 1; ++j) {
-                for (int k = 0; k <= 1; ++k) {
-                    for (int l = 0; l <= 1; ++l) {
-                        std::vector<double> point = {static_cast<double>(i), static_cast<double>(j), 
-                                                     static_cast<double>(k), static_cast<double>(l)};
-                        points.pointMap[point] = nonLinearFunction(point);
-                    }
-                }
-            }
-        }
-
-        // Test interpolation at various points
-        std::vector<std::vector<double>> testPoints = {
-            {0.0, 0.0, 0.0, 0.0},
-            {1.0, 1.0, 1.0, 1.0},
-            {0.5, 0.5, 0.5, 0.5},
-            {0.25, 0.75, 0.4, 0.6}
-        };
-
-        for (const auto& point : testPoints) {
-            double result = interpolate(point, points);
-            double expected = nonLinearFunction(point);
-            double tolerance = calculateTolerance(point, points);
-            TS_ASSERT_DELTA(result, expected, tolerance);
-        }
-        
-        std::cout << "Finished testEdgeCases4D" << std::endl;
-        std::cout << "#########################################\n" << std::endl;
+      // Increment indices
+      int dim = 0;
+      while (dim < numDimensions && ++indices[dim] == pointsPerDimension) {
+        indices[dim] = 0;
+        ++dim;
+      }
+      if (dim == numDimensions)
+        break;
     }
 
-    void testPerformance4D()
-    {
-        std::cout << "\n#########################################" << std::endl;
-        std::cout << "Starting testPerformance4D\n" << std::endl;
+    return points;
+  }
 
-        const int VECTOR_SIZE = 4;
-        std::vector<int> test_sizes = {5, 7, 10}; // Reduced sizes for a 4D grid
-
-        for (int GRID_SIZE : test_sizes) {
-            int NUM_POINTS = std::pow(GRID_SIZE, VECTOR_SIZE);
-            int NUM_QUERIES = 1000;
-
-            std::cout << "Testing with " << NUM_POINTS << " points (" << GRID_SIZE << " per dimension) and " << NUM_QUERIES << " queries" << std::endl;
-
-            PointCloud points = createRandomPointCloud(VECTOR_SIZE, GRID_SIZE);
-
-            // Generate random query points
-            std::random_device rd;
-            std::mt19937 gen(rd());
-            std::uniform_real_distribution<> dis(0.0, 2 * M_PI);
-
-            std::vector<std::vector<double>> queryPoints(NUM_QUERIES, std::vector<double>(VECTOR_SIZE));
-            for (auto& query : queryPoints) {
-                for (auto& coord : query) {
-                    coord = dis(gen);
-                }
-            }
-
-            // Measure time to interpolate all query points
-            auto start = std::chrono::high_resolution_clock::now();
-            for (const auto& query : queryPoints) {
-                volatile double result = interpolate(query, points);  // volatile to prevent optimization
-            }
-            auto end = std::chrono::high_resolution_clock::now();
-
-            std::chrono::duration<double> diff = end - start;
-            double avg_time = diff.count() / NUM_QUERIES;
-
-            std::cout << "Average time to interpolate a 4D point: " << std::fixed << std::setprecision(9) 
-                      << avg_time * 1e6 << " microseconds\n" << std::endl;
-        }
-        
-        std::cout << "\nFinished testPerformance4D" << std::endl;
-        std::cout << "#########################################\n" << std::endl;
-    }
-
-    // Add this function to your InterpolationTest class
-    double manualTrilinearInterpolation(const std::vector<double>& point, const PointCloud& points)
-    {
-        double x = point[0], y = point[1], z = point[2];
-        const auto& uniqueValues = points.uniqueValues;
-
-        // Find the indices of the surrounding cube
-        size_t ix = 0, iy = 0, iz = 0;
-        while (ix + 1 < uniqueValues[0].size() && uniqueValues[0][ix + 1] <= x) ++ix;
-        while (iy + 1 < uniqueValues[1].size() && uniqueValues[1][iy + 1] <= y) ++iy;
-        while (iz + 1 < uniqueValues[2].size() && uniqueValues[2][iz + 1] <= z) ++iz;
-
-        // Calculate the relative position within the cube
-        double x0 = uniqueValues[0][ix], x1 = uniqueValues[0][ix + 1];
-        double y0 = uniqueValues[1][iy], y1 = uniqueValues[1][iy + 1];
-        double z0 = uniqueValues[2][iz], z1 = uniqueValues[2][iz + 1];
-
-        double xd = (x - x0) / (x1 - x0);
-        double yd = (y - y0) / (y1 - y0);
-        double zd = (z - z0) / (z1 - z0);
-
-        // Get the values at the cube corners
-        double c000 = points.pointMap.at({x0, y0, z0});
-        double c001 = points.pointMap.at({x0, y0, z1});
-        double c010 = points.pointMap.at({x0, y1, z0});
-        double c011 = points.pointMap.at({x0, y1, z1});
-        double c100 = points.pointMap.at({x1, y0, z0});
-        double c101 = points.pointMap.at({x1, y0, z1});
-        double c110 = points.pointMap.at({x1, y1, z0});
-        double c111 = points.pointMap.at({x1, y1, z1});
-
-        // Perform trilinear interpolation
-        return c000 * (1-xd) * (1-yd) * (1-zd) +
-               c100 * xd * (1-yd) * (1-zd) +
-               c010 * (1-xd) * yd * (1-zd) +
-               c110 * xd * yd * (1-zd) +
-               c001 * (1-xd) * (1-yd) * zd +
-               c101 * xd * (1-yd) * zd +
-               c011 * (1-xd) * yd * zd +
-               c111 * xd * yd * zd;
-    }
-
-    void testValidity3DUniform()
-    {
-        std::cout << "\n#########################################" << std::endl;
-        std::cout << "Starting testAccuracy3DUniform\n" << std::endl;
-
-        // Create a 3D point cloud
-        PointCloud points;
-        points.numDimensions = 3;
-        points.uniqueValues = {{0.0, 1.0}, {0.0, 1.0}, {0.0, 1.0}};
-
-        // Define a simple 3D function
-        auto testFunction = [](const std::vector<double>& x) {
-            return x[0] * x[1] + x[2];
-        };
-
-        // Set up the 3D cube
-        for (int i = 0; i <= 1; ++i) {
-            for (int j = 0; j <= 1; ++j) {
-                for (int k = 0; k <= 1; ++k) {
-                    std::vector<double> point = {static_cast<double>(i), static_cast<double>(j), static_cast<double>(k)};
-                    points.pointMap[point] = testFunction(point);
-                }
-            }
-        }
-
-        // Test interpolation at various points
-        std::vector<std::vector<double>> testPoints = {
-            {0.5, 0.5, 0.5},
-            {0.25, 0.75, 0.4},
-            {0.1, 0.9, 0.3},
-            {0.8, 0.2, 0.6}
-        };
-
-        for (const auto& point : testPoints) {
-            double interpolated = interpolate(point, points);
-            double manual = manualTrilinearInterpolation(point, points);
-
-            std::cout << "Point: (" << point[0] << ", " << point[1] << ", " << point[2] << ")" << std::endl;
-            std::cout << "Interpolated: " << interpolated << std::endl;
-            std::cout << "Manual: " << manual << std::endl;
-
-            // Check if the interpolated value matches the manual calculation
-            TS_ASSERT_DELTA(interpolated, manual, 1e-10);
-        }
-
-        std::cout << "\nFinished testAccuracy3DUniform" << std::endl;
-        std::cout << "#########################################\n" << std::endl;
-    }
-
-    void testValidity3DNonUniform()
-    {
-        std::cout << "\n#########################################" << std::endl;
-        std::cout << "Starting testAccuracy3DNonUniform\n" << std::endl;
-
-        // Create a 3D point cloud with non-uniform spacing
-        PointCloud points;
-        points.numDimensions = 3;
-        points.uniqueValues = {{0.0, 1.0}, {0.0, 0.3}, {-2.1, 12.34}};
-
-        // Define a simple 3D function
-        auto testFunction = [](const std::vector<double>& x) {
-            return x[0] * x[1] + std::sin(x[2]);
-        };
-
-        // Set up the 3D grid
-        for (double x : points.uniqueValues[0]) {
-            for (double y : points.uniqueValues[1]) {
-                for (double z : points.uniqueValues[2]) {
-                    std::vector<double> point = {x, y, z};
-                    points.pointMap[point] = testFunction(point);
-                }
-            }
-        }
-
-        // Test interpolation at various points
-        std::vector<std::vector<double>> testPoints = {
-            {0.5, 0.15, 5.12},
-            {0.25, 0.2, 0.0},
-            {0.75, 0.1, 10.0},
-            {0.9, 0.25, -1.0}
-        };
-
-        for (const auto& point : testPoints) {
-            double interpolated = interpolate(point, points);
-            double expected = testFunction(point);
-            double manual = manualTrilinearInterpolation(point, points);
-
-            std::cout << "Point: (" << point[0] << ", " << point[1] << ", " << point[2] << ")" << std::endl;
-            std::cout << "Interpolated: " << interpolated << std::endl;
-            std::cout << "Manual: " << manual << "\n"<< std::endl;
-            // Check if the interpolated value matches the manual calculation
-            TS_ASSERT_DELTA(interpolated, manual, 1e-10);
-
-            // Check if the interpolated value is close to the expected value
-            // We use a larger tolerance here because trilinear interpolation is an approximation
-            // TS_ASSERT_DELTA(interpolated, expected, 0.1);
-        }
-
-        std::cout << "\nFinished testAccuracy3DNonUniform" << std::endl;
-        std::cout << "#########################################\n" << std::endl;
-    }
-
-void testOutOfBoundsInterpolation()
-{
+  void testBasicInterpolation() {
     std::cout << "\n#########################################" << std::endl;
-    std::cout << "Starting testOutOfBoundsInterpolation\n" << std::endl;
+    std::cout << "Starting testBasicInterpolation\n" << std::endl;
 
-    // Create a 3D point cloud
+    PointCloud points = createRandomPointCloud(4, 2);
+
+    // Test interpolation at the center of the hypercube
+    std::vector<double> queryPoint(4, 0.5);
+    double result = interpolate(queryPoint, points);
+    double expected = nonLinearFunction(queryPoint);
+    double tolerance = calculateTolerance(queryPoint, points);
+    TS_ASSERT_DELTA(result, expected, tolerance);
+
+    std::cout << "\nFinished testBasicInterpolation" << std::endl;
+    std::cout << "#########################################\n" << std::endl;
+  }
+
+  void testEdgeCases() {
+    std::cout << "\n#########################################" << std::endl;
+    std::cout << "Starting testEdgeCases\n" << std::endl;
+
+    PointCloud points = createRandomPointCloud(3, 2);
+
+    std::vector<std::vector<double>> testPoints = {
+        {0.0, 0.0, 0.0},
+        {2 * M_PI, 2 * M_PI, 2 * M_PI},
+        {M_PI, M_PI, M_PI},
+        {M_PI / 2, 3 * M_PI / 4, M_PI / 4}};
+
+    for (const auto &point : testPoints) {
+      double result = interpolate(point, points);
+      double expected = nonLinearFunction(point);
+      double tolerance = calculateTolerance(point, points);
+      TS_ASSERT_DELTA(result, expected, tolerance);
+    }
+
+    std::cout << "Finished testEdgeCases" << std::endl;
+    std::cout << "#########################################\n" << std::endl;
+  }
+
+  void testPerformance() {
+    std::cout << "\n#########################################" << std::endl;
+    std::cout << "Starting testPerformance\n" << std::endl;
+
+    const int VECTOR_SIZE = 4;
+    std::vector<int> test_sizes = {3, 4, 5};
+
+    for (int GRID_SIZE : test_sizes) {
+      int NUM_POINTS = std::pow(GRID_SIZE, VECTOR_SIZE);
+      int NUM_QUERIES = 1000;
+
+      std::cout << "Testing with " << NUM_POINTS << " points (" << GRID_SIZE
+                << " per dimension) and " << NUM_QUERIES << " queries"
+                << std::endl;
+
+      PointCloud points = createRandomPointCloud(VECTOR_SIZE, GRID_SIZE);
+
+      // Generate random query points
+      std::random_device rd;
+      std::mt19937 gen(rd());
+      std::uniform_real_distribution<> dis(0.0, 2 * M_PI);
+
+      std::vector<std::vector<double>> queryPoints(
+          NUM_QUERIES, std::vector<double>(VECTOR_SIZE));
+      for (auto &query : queryPoints) {
+        for (auto &coord : query) {
+          coord = dis(gen);
+        }
+      }
+
+      // Measure time to interpolate all query points
+      auto start = std::chrono::high_resolution_clock::now();
+      for (const auto &query : queryPoints) {
+        volatile double result =
+            interpolate(query, points); // volatile to prevent optimization
+      }
+      auto end = std::chrono::high_resolution_clock::now();
+
+      std::chrono::duration<double> diff = end - start;
+      double avg_time = diff.count() / NUM_QUERIES;
+
+      std::cout << "Average time to interpolate a " << VECTOR_SIZE
+                << "D point: " << std::fixed << std::setprecision(9)
+                << avg_time * 1e6 << " microseconds\n"
+                << std::endl;
+    }
+
+    std::cout << "\nFinished testPerformance" << std::endl;
+    std::cout << "#########################################\n" << std::endl;
+  }
+
+  void testValidityUniform() {
+    std::cout << "\n#########################################" << std::endl;
+    std::cout << "Starting testValidityUniform\n" << std::endl;
+
+    PointCloud points = createRandomPointCloud(3, 3);
+
+    std::vector<std::vector<double>> testPoints = {
+        {M_PI / 2, M_PI / 2, M_PI / 2},
+        {M_PI / 4, 3 * M_PI / 4, M_PI / 2},
+        {M_PI / 6, 5 * M_PI / 6, M_PI / 3},
+        {4 * M_PI / 5, M_PI / 5, 3 * M_PI / 5}};
+
+    for (const auto &point : testPoints) {
+      double interpolated = interpolate(point, points);
+      double expected = nonLinearFunction(point);
+
+      std::cout << "Point: (" << point[0] << ", " << point[1] << ", "
+                << point[2] << ")" << std::endl;
+      std::cout << "Interpolated: " << interpolated << std::endl;
+      std::cout << "Expected: " << expected << std::endl;
+
+      double tolerance = calculateTolerance(point, points);
+      TS_ASSERT_DELTA(interpolated, expected, tolerance);
+    }
+
+    std::cout << "\nFinished testValidityUniform" << std::endl;
+    std::cout << "#########################################\n" << std::endl;
+  }
+
+  void testValidityNonUniform() {
+    std::cout << "\n#########################################" << std::endl;
+    std::cout << "Starting testValidityNonUniform\n" << std::endl;
+
     PointCloud points;
     points.numDimensions = 3;
-    points.uniqueValues = {{0.0, 1.0, 2.0}, {0.0, 1.0, 2.0}, {0.0, 1.0, 2.0}};
+    points.uniqueValues = {
+        {0.0, 1.0, 2.5}, {0.0, 0.3, 1.2}, {-2.1, 0.0, 12.34}};
 
     // Set up the 3D grid
     for (double x : points.uniqueValues[0]) {
-        for (double y : points.uniqueValues[1]) {
-            for (double z : points.uniqueValues[2]) {
-                std::vector<double> point = {x, y, z};
-                points.pointMap[point] = x * y + z; // Simple function for point values
-            }
+      for (double y : points.uniqueValues[1]) {
+        for (double z : points.uniqueValues[2]) {
+          std::vector<double> point = {x, y, z};
+          points.pointMap[point] = nonLinearFunction(point);
         }
+      }
     }
 
-    // Test interpolation at various out-of-bounds points
+    std::vector<std::vector<double>> testPoints = {{0.5, 0.15, 5.12},
+                                                   {1.75, 0.6, 0.0},
+                                                   {2.0, 0.9, 10.0},
+                                                   {0.9, 0.25, -1.0}};
+
+    for (const auto &point : testPoints) {
+      double interpolated = interpolate(point, points);
+      double expected = nonLinearFunction(point);
+
+      std::cout << "Point: (" << point[0] << ", " << point[1] << ", "
+                << point[2] << ")" << std::endl;
+      std::cout << "Interpolated: " << interpolated << std::endl;
+      std::cout << "Expected: " << expected << "\n" << std::endl;
+
+      double tolerance = calculateTolerance(point, points);
+      TS_ASSERT_DELTA(interpolated, expected, tolerance);
+    }
+
+    std::cout << "\nFinished testValidityNonUniform" << std::endl;
+    std::cout << "#########################################\n" << std::endl;
+  }
+
+  void testOutOfBoundsInterpolation() {
+    std::cout << "\n#########################################" << std::endl;
+    std::cout << "Starting testOutOfBoundsInterpolation\n" << std::endl;
+
+    PointCloud points = createRandomPointCloud(3, 3);
+
     std::vector<std::vector<double>> testPoints = {
-        {-1.0, 0.5, 0.5},  // Out of bounds in x (low)
-        {3.0, 0.5, 0.5},   // Out of bounds in x (high)
-        {0.5, -1.0, 0.5},  // Out of bounds in y (low)
-        {0.5, 3.0, 0.5},   // Out of bounds in y (high)
-        {0.5, 0.5, -1.0},  // Out of bounds in z (low)
-        {0.5, 0.5, 3.0},   // Out of bounds in z (high)
-        {-1.0, -1.0, -1.0},// Out of bounds in all dimensions (low)
-        {3.0, 3.0, 3.0}    // Out of bounds in all dimensions (high)
-    };
+        {-1.0, M_PI, M_PI}, {3 * M_PI, M_PI, M_PI},
+        {M_PI, -1.0, M_PI}, {M_PI, 3 * M_PI, M_PI},
+        {M_PI, M_PI, -1.0}, {M_PI, M_PI, 3 * M_PI},
+        {-1.0, -1.0, -1.0}, {3 * M_PI, 3 * M_PI, 3 * M_PI}};
 
-    for (const auto& point : testPoints) {
-        double outOfBoundsResult = interpolate(point, points);
-        
-        // Create an in-bounds point by clamping coordinates to the grid boundaries
-        std::vector<double> inBoundsPoint = point;
-        for (size_t i = 0; i < point.size(); ++i) {
-            inBoundsPoint[i] = std::max(points.uniqueValues[i].front(), 
-                               std::min(point[i], points.uniqueValues[i].back()));
-        }
-        
-        double inBoundsResult = interpolate(inBoundsPoint, points);
+    for (const auto &point : testPoints) {
+      double outOfBoundsResult = interpolate(point, points);
 
-        std::cout << "Out-of-bounds point: (" << point[0] << ", " << point[1] << ", " << point[2] << ")" << std::endl;
-        std::cout << "In-bounds point: (" << inBoundsPoint[0] << ", " << inBoundsPoint[1] << ", " << inBoundsPoint[2] << ")" << std::endl;
-        std::cout << "Out-of-bounds result: " << outOfBoundsResult << std::endl;
-        std::cout << "In-bounds result: " << inBoundsResult << std::endl;
+      std::vector<double> inBoundsPoint = point;
+      for (size_t i = 0; i < point.size(); ++i) {
+        inBoundsPoint[i] =
+            std::max(points.uniqueValues[i].front(),
+                     std::min(point[i], points.uniqueValues[i].back()));
+      }
 
-        // Check if the out-of-bounds interpolation matches the in-bounds interpolation
-        TS_ASSERT_DELTA(outOfBoundsResult, inBoundsResult, 1e-10);
-        
-        std::cout << std::endl;
+      double inBoundsResult = interpolate(inBoundsPoint, points);
+
+      std::cout << "Out-of-bounds point: (" << point[0] << ", " << point[1]
+                << ", " << point[2] << ")" << std::endl;
+      std::cout << "In-bounds point: (" << inBoundsPoint[0] << ", "
+                << inBoundsPoint[1] << ", " << inBoundsPoint[2] << ")"
+                << std::endl;
+      std::cout << "Out-of-bounds result: " << outOfBoundsResult << std::endl;
+      std::cout << "In-bounds result: " << inBoundsResult << std::endl;
+
+      TS_ASSERT_DELTA(outOfBoundsResult, inBoundsResult, 1e-10);
+
+      std::cout << std::endl;
     }
 
     std::cout << "Finished testOutOfBoundsInterpolation" << std::endl;
     std::cout << "#########################################\n" << std::endl;
-}
+  }
 };


### PR DESCRIPTION
This PR fixes and refactors the ND interpolator used to manage aero data in sims. The issue fixed was caused by lower bound crossing the upper bound during the recursive interpolation search. This has been removed and re-implemented. Previous issue would sometimes crash the sim with this exception.