### PR TITLE
Add slack to fgtable interpolation

### DIFF
--- a/src/math/FGTable.cpp
+++ b/src/math/FGTable.cpp
@@ -509,8 +509,7 @@ double FGTable::GetValue(double key) const
   double Span = Data[2*r] - x0;
   assert(Span > 0.0);
   double Factor = (key - x0) / Span;
-  const double epsilon = 1e-9;
-  assert(Factor >= -epsilon && Factor <= 1.0 + epsilon);
+  assert(Factor >= -EPSILON && Factor <= 1.0 + EPSILON);
 
 
   double y0 = Data[2*r-1];

--- a/src/math/FGTable.cpp
+++ b/src/math/FGTable.cpp
@@ -509,7 +509,9 @@ double FGTable::GetValue(double key) const
   double Span = Data[2*r] - x0;
   assert(Span > 0.0);
   double Factor = (key - x0) / Span;
-  assert(Factor >= 0.0 && Factor <= 1.0);
+  const double epsilon = 1e-9;
+  assert(Factor >= -epsilon && Factor <= 1.0 + epsilon);
+
 
   double y0 = Data[2*r-1];
   return Factor*(Data[2*r+1] - y0) + y0;

--- a/src/math/FGTable.h
+++ b/src/math/FGTable.h
@@ -313,6 +313,8 @@ public:
 
   std::string GetName(void) const {return Name;}
 
+  static constexpr double EPSILON = 1e-9;
+
 private:
   enum type {tt1D, tt2D, tt3D} Type;
   enum axis {eRow=0, eColumn, eTable};


### PR DESCRIPTION
Factor can move out of bounds when we do wind calculations (some numerical stuff upstream of this). Adding epsilon helps solve the issue here.

Fixes this issue at low initial speeds and high winds:
```
Assertion failed: (Factor >= 0.0 && Factor <= 1.0), function GetValue, file FGTable.cpp, line 512.
```

Tested with wind sims locally and able to reproduce same results without any of the previous assertion triggered crashes coming from the Factor being out of bounds.