### PR TITLE
dont set upper and lower bounds to be the same

### DIFF
--- a/src/math/Interpolation.cpp
+++ b/src/math/Interpolation.cpp
@@ -78,8 +78,7 @@ double interpolateRecursive(
 
   // Handle the case where lower and upper bounds are the same
   if (std::abs(upperValue - lowerValue) < EPSILON) {
-    std::vector<std::vector<double>::const_iterator> nextBounds = lowerBounds;
-    return interpolateRecursive(queryPoint, points, nextBounds, nextBounds,
+    return interpolateRecursive(queryPoint, points, lowerBounds, upperBounds,
                                 dimension + 1);
   }
 


### PR DESCRIPTION
If the bounds are equal, the if statement sets the lower and upper bounds identical, so it recurses down and getValueAtPoint of the lower bounds value. Instead, it should hold that value in that dimension as it has hit a boundary.